### PR TITLE
Add streamed output variant and specs mode as separate enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ I'm still determining the value/viability of these, but the opportunities sound 
 - [Non-Deterministic Backpressure](#non-deterministic-backpressure) - Using LLM-as-judge for tests against subjective tasks (tone, aesthetics, UX). Binary pass/fail reviews that iterate until pass.
 - [Ralph-Friendly Work Branches](#ralph-friendly-work-branches) - Asking Ralph to "filter to feature X" at runtime is unreliable. Instead, create scoped plan per branch upfront.
 - [JTBD → Story Map → SLC Release](#jtbd--story-map--slc-release) - Push the power of "Letting Ralph Ralph" to connect JTBD's audience and activities to Simple/Lovable/Complete releases.
-- [Specs Mode](#specs-mode) - Dedicated mode for generating/maintaining specs with quality rules: behavioral outcomes only, topic scoping, consistent naming.
+- [Specs Audit](#specs-audit) - Dedicated mode for generating/maintaining specs with quality rules: behavioral outcomes only, topic scoping, consistent naming.
 
 ---
 
@@ -1257,7 +1257,7 @@ _Cardinalities:_
 
 ---
 
-### Specs Mode
+### Specs Audit
 
 A dedicated loop mode for generating and maintaining spec files with enforced quality rules. Ensures specs stay focused on behavioral outcomes (not implementation details), properly scoped topics ("one sentence without 'and'"), and consistent file naming conventions.
 
@@ -1312,7 +1312,7 @@ _Notes:_
 
 1. Identify Jobs to Be Done (JTBD) → Break individual JTBD into topic(s) of concern → Use subagents to load info from URLs into context → LLM understands JTBD topic of concern: subagent writes specs/FILENAME.md for each topic.
 
-## RULES (dont apply to `specs/README.md`)
+## RULES (don't apply to `specs/README.md`)
 
 999. NEVER add code blocks or suggest how a variable should be named. This will be decided by Ralph.
 

--- a/files/PROMPT_specs.md
+++ b/files/PROMPT_specs.md
@@ -2,7 +2,7 @@
 
 1. Identify Jobs to Be Done (JTBD) → Break individual JTBD into topic(s) of concern → Use subagents to load info from URLs into context → LLM understands JTBD topic of concern: subagent writes specs/FILENAME.md for each topic.
 
-## RULES (dont apply to `specs/README.md`)
+## RULES (don't apply to `specs/README.md`)
 
 999. NEVER add code blocks or suggest how a variable should be named. This will be decided by Ralph.
 

--- a/files/loop_streamed.sh
+++ b/files/loop_streamed.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 # Usage: ./loop_streamed.sh [plan] [max_iterations]
 # Examples:
 #   ./loop_streamed.sh              # Build mode, unlimited iterations
@@ -68,7 +69,7 @@ Execute the instructions above."
         --model opus \
         --verbose \
         --output-format stream-json \
-        --include-partial-messages 2>&1 | node "$SCRIPT_DIR/parse_stream.js"
+        --include-partial-messages | node "$SCRIPT_DIR/parse_stream.js"
 
     echo ""
     echo "✅ Claude iteration complete"

--- a/files/parse_stream.js
+++ b/files/parse_stream.js
@@ -278,6 +278,6 @@ rl.on('line', (line) => {
       // console.log(`${colors.dim}Debug result keys: ${Object.keys(data).join(', ')}${colors.reset}`);
     }
   } catch (e) {
-    // Ignore parse errors for non-JSON lines
+    if (line.trim()) process.stderr.write(line + '\n');
   }
 });

--- a/index.html
+++ b/index.html
@@ -3489,7 +3489,7 @@ ULTIMATE GOAL: We want to achieve the most valuable next release for the audienc
 
             <details>
               <summary>
-                <span class="summary-title">Specs Mode</span>
+                <span class="summary-title">Specs Audit</span>
                 <span class="summary-desc"
                   >Dedicated mode for generating/maintaining specs with quality
                   rules: behavioral outcomes only, topic scoping, consistent


### PR DESCRIPTION
Adds two independent enhancements per feedback on the previous PR:

  - **Streamed Output Variant** — `loop_streamed.sh` + `parse_stream.js` that    
  pipes Claude's raw JSON through a Node.js parser for readable, color-coded     
  terminal output (tool calls, results, execution stats). Added as a sub-section 
  at the end of "Loop Mechanics".

  - **Specs Mode** — A dedicated loop mode for generating/maintaining spec files 
  with enforced quality rules (behavioral outcomes only, topic scoping,
  consistent naming). Added as a new entry in "Enhancements?" with
  `PROMPT_specs.md` template and instructions for adding specs support to either 
  loop script.

  ## Changes

  | File | Description |
  |------|-------------|
  | `files/loop_streamed.sh` | Streaming variant of loop.sh (plan/build only) |  
  | `files/parse_stream.js` | Node.js stream parser for Claude's stream-json     
  output |
  | `files/PROMPT_specs.md` | Specs mode prompt template |
  | `README.md` | Streamed Output sub-section + Specs Mode enhancement |
  | `index.html` | Synced both new sections to match README |

  ## Notes

  - Original `loop.sh` is untouched
  - `loop_streamed.sh` has no dependency on specs mode — the two enhancements are
   fully independent
  - Specs mode includes concrete `elif` code snippet for adding support to both  
  `loop.sh` and `loop_streamed.sh`
  - All additions only — no modifications to existing files or content