### PR TITLE
Add MIT license and asset notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The Ralph Playbook contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+Unless otherwise noted, the contents of this repository are licensed under the
+MIT License; see LICENSE.
+
+Excluded from the MIT License:
+
+- Third-party screenshots and externally sourced images, including
+  `references/nah.png`
+- Third-party logos, trademarks, and brand assets reproduced for commentary,
+  attribution, or reference
+
+Those excluded materials remain subject to their original terms and permissions.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Hope this helps you out - [@ClaytonFarr](https://x.com/ClaytonFarr)
 - [Workflow](#workflow)
 - [Key Principles](#key-principles)
 - [Loop Mechanics](#loop-mechanics)
+- [License](#license)
 - [Files](#files)
 - [Enhancements?](#enhancements)
 
@@ -376,6 +377,13 @@ _Differences from base `loop.sh`:_
 _Files:_ [`loop_streamed.sh`](files/loop_streamed.sh) · [`parse_stream.js`](files/parse_stream.js)
 
 — contributed by [@terry-xyz](https://github.com/terry-xyz) · [@blackrosesxyz](https://x.com/blackrosesxyz)
+
+## License
+
+This repository is available under the [MIT License](LICENSE).
+
+Third-party screenshots and externally sourced images are excluded unless
+explicitly noted otherwise. See [NOTICE](NOTICE) for details.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -3660,6 +3660,11 @@ If you need "and" to describe what it does, it's probably multiple topics
               <a href="https://github.com/ClaytonFarr/ralph-playbook">GitHub</a
               >.
             </p>
+            <p>
+              Licensed under the <a href="LICENSE">MIT License</a>. Third-party
+              screenshots and externally sourced images are excluded; see
+              <a href="NOTICE">NOTICE</a>.
+            </p>
           </footer>
         </main>
 


### PR DESCRIPTION
## Summary
- add a root MIT `LICENSE`
- add a `NOTICE` file excluding third-party screenshots and externally sourced images
- mention licensing in `README.md` and the public `index.html` footer

## Context
Issue #7 asked for a repo license. The repository is currently public but unlicensed, which leaves reuse unclear by default. This change adds a simple permissive license and clarifies that third-party screenshots/assets are not covered.

Issue: #7